### PR TITLE
Remove popups when leaving dashboard and search pages.

### DIFF
--- a/routes/client.coffee
+++ b/routes/client.coffee
@@ -49,6 +49,7 @@ Router.map () ->
     onStop: () ->
       Session.set('disease', null)
       Session.set('features', [])
+      $('.popover').remove()
   )
 
   @route("search",
@@ -77,6 +78,8 @@ Router.map () ->
           if diagnosis.keywords
             diagnosis.keywords.forEach (k)->
               AnyKeywordsSelected.insert(k)
+    onStop: () ->
+      $('.popover').remove()
   )
 
   @route("symptomTable",


### PR DESCRIPTION
This fixes a bug where the popups from clicking a point on the map would persist when you went to another page, like detailed diagnosis.
