### PR TITLE
Adding method for loading additional search results

### DIFF
--- a/0collections/config.coffee
+++ b/0collections/config.coffee
@@ -1,2 +1,3 @@
 @grits ?= {}
 @grits.Config = new Meteor.Collection("config")
+@grits.searchLimit = 50

--- a/client/0views/search.jade
+++ b/client/0views/search.jade
@@ -25,6 +25,10 @@ template(name="search")
       +inputAutocomplete settings=keywordCompleteSettings id="new-all-keyword" class="input-xlarge"
       button(id="add-all-keyword") Add
     .pane-container
+      if additionalResults
+        .more-results-bar
+          | There were too many search results to load them all at once
+          a#load-more-results.btn.btn-warning.btn-sm Load additional results
       .pane
         +geomapSimple
       .pane

--- a/client/controllers/search.coffee
+++ b/client/controllers/search.coffee
@@ -102,6 +102,9 @@ Template.search.diseaseCompleteSettings = ()->
    ]
   }
 
+Template.search.additionalResults = ()->
+  Session.get("additionalResults", true) or false
+
 Template.search.keywordCompleteSettings = ()->
   {
    position: "top",
@@ -139,11 +142,18 @@ Deps.autorun ()->
         $all : AllKeywordsSelected.find().map((k)-> k.name)
       }
     })
+  
   if conditions.length > 0
+    limit = Session.get('skip') + grits.searchLimit
+    Session.set("additionalResults", false)
     Meteor.subscribe('item', {
       $and : conditions
     }, {
-      onready : ()->
+      limit : limit
+    }, {
+      onReady : (x,y)->
+        if grits.Girder.Items.find().count() >= limit
+          Session.set("additionalResults", true)
         console.log "reports loaded"
     })
 
@@ -162,21 +172,32 @@ Template.search.events
 
   "click #add-disease" : (event) ->
     DiseasesSelected.insert({name : $("#new-disease").val()})
+    Session.get('skip', 0)
 
   "click .remove-disease" : (event) ->
     DiseasesSelected.remove({name : $(event.currentTarget).data('name')})
+    Session.get('skip', 0)
 
   "click #add-any-keyword" : (event) ->
     AnyKeywordsSelected.insert({name : $("#new-any-keyword").val()})
+    Session.set('skip', 0)
 
   "click .remove-any-keyword" : (event) ->
     AnyKeywordsSelected.remove({name : $(event.currentTarget).data('name')})
+    Session.set('skip', 0)
 
   "click #add-all-keyword" : (event) ->
     AllKeywordsSelected.insert({name : $("#new-all-keyword").val()})
+    Session.set('skip', 0)
 
   "click .remove-all-keyword" : (event) ->
     AllKeywordsSelected.remove({name : $(event.currentTarget).data('name')})
+    Session.set('skip', 0)
 
   "click .reset-panels": (event) ->
     setHeights()
+
+  "click #load-more-results" : (event) ->
+    console.log("x")
+    console.log grits.searchLimit
+    Session.set('skip', Session.get('skip') + grits.searchLimit)

--- a/client/stylesheets/dash.styl
+++ b/client/stylesheets/dash.styl
@@ -62,6 +62,7 @@
   flex-direction row
   align-items left
   flex-wrap wrap
+  position relative
 
 .pane
   flex 0 1 auto

--- a/client/stylesheets/search.styl
+++ b/client/stylesheets/search.styl
@@ -31,3 +31,12 @@
 
 .inline-list span:last-child:after
     content ""
+
+.more-results-bar
+    position: absolute
+    z-index: 100
+    background-color: cornsilk
+    padding: 3px
+    left: 0
+    right: 0
+    color: black

--- a/routes/client.coffee
+++ b/routes/client.coffee
@@ -55,15 +55,15 @@ Router.map () ->
   @route("search",
     path: '/search'
     where: 'client'
-    onBeforeAction: () ->
-      AccountsEntry.signInRequired(@)
     waitOn: () ->
       [
         Meteor.subscribe('diseaseNames')
         Meteor.subscribe('keywords')
         Meteor.subscribe('results')
       ]
-    onAfterAction: ()->
+    onBeforeAction: ()->
+      AccountsEntry.signInRequired(@)
+      Session.setDefault('skip', 0)
       # Remove any previous selections which could exist
       # if the user navigates away from the search page and comes back.
       DiseasesSelected.find({},{reactive:false}).forEach (d)->
@@ -80,6 +80,7 @@ Router.map () ->
               AnyKeywordsSelected.insert(k)
     onStop: () ->
       $('.popover').remove()
+      Session.set('skip', 0)
   )
 
   @route("symptomTable",

--- a/server/girder.coffee
+++ b/server/girder.coffee
@@ -1,9 +1,18 @@
 Items = () =>
   @grits.Girder.Items
 
-Meteor.publish("item", (query) ->
+Meteor.publish("item", (query, options) ->
     if @userId
+      allOptions = {
+        limit: grits.searchLimit,
+        fields : {
+          meta: 1,
+          description: 1
+        }
+      }
+      if _.isObject(options)
+        _.extend(allOptions, options)
       # The limit can cause seemingly inconsistent results where narrowing down
       # a queries causes articles to appear.
-      Items().find(query, {limit: 100, fields : {'meta':1, 'description':1}})
+      Items().find(query, allOptions)
 )


### PR DESCRIPTION
This PR adds a banner to the search page that alerts the user when additional results are available (that were not displayed due to bandwidth constraints) and gives them the ability to load them if they are. Here's a screen shot of it:

![addedresults](https://cloud.githubusercontent.com/assets/710024/3717140/c5556a22-1620-11e4-8c42-a637ad979a76.PNG)

This PR is currently just a request for review. I don't think this code is ready to be deployed. The main problem is that I think the queries are not efficiently paginated, so loading additional results effectively reloads everything with a greater limit. I tried using a skip in the publish query but this causes the previous results to disappear, which might be a viable option. Another thing we could do is add skip and limit fields to the query panel.
