### PR TITLE
Fixing highlighted text html injection bug

### DIFF
--- a/client/controllers/text.coffee
+++ b/client/controllers/text.coffee
@@ -31,12 +31,14 @@ Template.text.highlight = (content) ->
       last_idx = 0
       for feature in featuresByOccurrence
         occurrence = feature.occurrence
-        highlightedContent += content.substring(last_idx, occurrence[0])
+        # Handlebars._escape is used to prevent formatting like <a@b.com>
+        # from being injected as live html.
+        highlightedContent += Handlebars._escape(content.substring(last_idx, occurrence[0]))
         if feature.feature.color
           bgColor = feature.feature.color
         else
           bgColor = color(feature.feature)
-        highlightText = content.substring(occurrence[0], occurrence[1])
+        highlightText = Handlebars._escape(content.substring(occurrence[0], occurrence[1]))
         highlightedContent += """<span
           class='label'
           style='
@@ -44,14 +46,15 @@ Template.text.highlight = (content) ->
             box-shadow: 0px 0px 0px 2px #{bgColor};
           '>#{highlightText}</span>"""
         last_idx = occurrence[1]
-      highlightedContent += content.substring(last_idx, content.length)
+      highlightedContent += Handlebars._escape(content.substring(last_idx, content.length))
       return new Spacebars.SafeString(highlightedContent)
     else if features?.length > 0
       features = _.sortBy(features, (feature) -> (feature.name or feature.text).length)
-      highlightedContent = content
+      highlightedContent = Handlebars._escape(content)
       for feature in features
         featureDisplay = feature.name or feature.text
         bgColor = color(feature)
+        # The escaping might break this regex.
         highlightedContent = highlightedContent.replace(
           new RegExp("\\b#{featureDisplay}\\b", 'gi'),
           "<span class='label' style='background-color:#{bgColor};" +


### PR DESCRIPTION
This prevents email addresses like `<a@b.com>` from disappearing and avoids a potential security vulnerability.
