### PR TITLE
Limiting results subscriptions to only required items

### DIFF
--- a/routes/client.coffee
+++ b/routes/client.coffee
@@ -25,7 +25,7 @@ Router.map () ->
     waitOn: () ->
       [
         Meteor.subscribe('users')
-        Meteor.subscribe('results')
+        Meteor.subscribe('results', {userId: (@params._id or Meteor.userId())})
       ]
     data: () ->
       userId = @params._id or Meteor.userId()
@@ -45,7 +45,7 @@ Router.map () ->
       [
         Meteor.subscribe('item')
         Meteor.subscribe('feedback')
-        Meteor.subscribe('results', @params._id)
+        Meteor.subscribe('results', {_id: @params._id})
       ]
     data: () ->
       data = Results.findOne(@params._id)
@@ -78,7 +78,7 @@ Router.map () ->
       [
         Meteor.subscribe('diseaseNames')
         Meteor.subscribe('keywords')
-        Meteor.subscribe('results', @params.diagnosisId)
+        Meteor.subscribe('results', {_id: @params.diagnosisId})
       ]
     onAfterAction: ()->
       # Remove any previous selections which could exist

--- a/server/results.coffee
+++ b/server/results.coffee
@@ -1,13 +1,6 @@
 Results = @grits.Results
 
-Meteor.publish('results', (resultId) ->
+Meteor.publish('results', (query) ->
   if @userId
-    if resultId
-      Results.find({
-        _id: resultId
-      })
-    else
-      Results.find({
-        userId: @userId
-      })
+    Results.find(query)
 )


### PR DESCRIPTION
This PR makes it so only the user's results are subscribed to on the profile page, and only the requested results are published on the dashboard and search pages. I believe this prevents unnecessary results from being downloaded and makes results private since you need to know the id to see someone else's results.
