### PR TITLE
Changing symptom table page to a view pane

### DIFF
--- a/client/0views/dash.jade
+++ b/client/0views/dash.jade
@@ -13,9 +13,6 @@ template(name="dash")
       .btn-group.btn-group-justified(style="margin-top:5px;")
         a.btn.btn-default(href='/search?diagnosisId=#{_id}') Find Similar Articles
       h4 Diagnosis
-        span.btn-group.btn-group-xs(style="float:right;")
-          a.btn.btn-default(href='/symptomTable/#{_id}') Detailed diagnosis
-          a.btn.btn-default.open-feedback Feedback
       +reactiveTable collection=diseases settings=tableSettings
       .btn-group.btn-group-justified.btn-group-sm
         if prevDiagnosisId
@@ -25,6 +22,8 @@ template(name="dash")
           a.btn.btn-default.prev-diagnosis(href='/dash/#{updatedDiagnosisId}') Updated Diagnosis
         else
           a.btn.btn-default.rediagnose Rediagnose
+      .btn-group.btn-group-justified.btn-group-sm
+        a.btn.btn-default.open-feedback Feedback
       +feedback
       if showKeypoints
         .keypoints
@@ -153,5 +152,7 @@ template(name="dash")
           +geomapSimple
         else if eq useView "timeline"
           +timelineSimple
+        else if eq useView "symptomTable"
+          +symptomTable
         else
           +text

--- a/client/0views/symptomTable.jade
+++ b/client/0views/symptomTable.jade
@@ -1,7 +1,6 @@
 template(name="symptomTable")
-  .dashboard-container
-    .diagnosis(style="flex: 0 0 100%;")
-      h4 Detailed Diagnosis
-        span.btn-group.btn-group-xs(style="float:right;")
-          a.btn.btn-default(href='/dash/#{_id}') Less detailed diagnosis
-      +reactiveTable collection=symptomTableCollection settings=tableSettings
+  .symptom-table
+    +reactiveTable collection=symptomTableCollection settings=tableSettings
+    p.info
+      | The values in this table correspond to the relative weights the keywords
+      | in each column had in determining the disease classifications in each row.

--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -93,7 +93,7 @@ Template.dash.tableSettings = () ->
   fields: [
     {
       key: 'probability'
-      label: 'Probability'
+      label: 'Confidence'
       sort: -1
       fn: (prob) ->
         Math.round(prob * 1000) / 1000
@@ -134,6 +134,9 @@ Template.dash.viewTypes = [
   }, {
     name: "timeline"
     label: "Timeline"
+  }, {
+    name: "symptomTable"
+    label: "Detailed Diagnosis"
   }
 ]
 

--- a/client/controllers/symptomTable.coffee
+++ b/client/controllers/symptomTable.coffee
@@ -1,47 +1,3 @@
-color = d3.scale.category20()
-
-Template.symptomTable.eq = (a, b) ->
-  a == b
-
-Template.symptomTable.showCategory = (category) ->
-  if category in ['datetime', 'caseCount', 'deathCount', 'hospitalizationCount', 'location']
-    _.any(@features, (feature) ->
-      feature.type is category
-    )
-  else
-    _.any(@keywords, (keyword) ->
-      _.any(keyword.categories, (keywordCategory) ->
-        keywordCategory.indexOf(category) >= 0
-      )
-    )
-
-Template.symptomTable.hasCategory = (keywordCategories, category) ->
-  _.any(keywordCategories, (keywordCategory) ->
-    keywordCategory.indexOf(category) >= 0
-  )
-
-Template.symptomTable.formatLocation = () ->
-  location = "#{@name}"
-  admin1Code = @['admin1 code'] # e.g., state
-  location += ", #{admin1Code}" if admin1Code and /^[a-z]+$/i.test(admin1Code)
-  countryCode = @['country code']
-  location += ", #{countryCode}" if countryCode
-  location
-
-Template.symptomTable.formatDate = () ->
-  date = new Date(@value)
-  date.setDate(date.getDate() + 1)
-  date.toLocaleDateString()
-
-Template.symptomTable.color = () ->
-  color @name
-
-Template.symptomTable.selected = () ->
-  @name == Session.get('disease')
-  
-Template.symptomTable.diagnosisId = () ->
-  window.location.pathname.split('/').pop()
-
 Template.symptomTable.symptomTableCollection = ()->
   if @diseases
     _.map @diseases, (disease)->
@@ -59,31 +15,7 @@ Template.symptomTable.tableSettings = () ->
      .uniq()
      .value()
   fields: [
-    {
-      key: 'probability'
-      label: 'Probability'
-      sort: -1
-      fn: (prob) ->
-        Math.round(prob * 1000) / 1000
-    },
-    {
-      key: 'name'
-      label: ' '
-      fn: (name) ->
-        if Session.equals('disease', name)
-          Spacebars.SafeString '<span style="color: green">&#10004;</span>'
-    },
     { key: 'name', label: 'Disease' },
-    {
-      key: 'keywords'
-      label: 'Characteristics'
-      fn: (features) ->
-        html = ""
-        _.each features, (feature) ->
-          featureColor = color feature.name
-          html += "<span style='background-color:#{featureColor}'>&nbsp;</span>&ensp;"
-        Spacebars.SafeString html
-    }
   ].concat(_.map symptoms, (name)->
     {
       key: name
@@ -94,9 +26,3 @@ Template.symptomTable.tableSettings = () ->
   )
   showNavigation: 'never'
   showFilter: false
-
-
-Template.symptomTable.events
-  "click .diagnosis .reactive-table tbody tr" : (event) ->
-    Session.set('disease', @name)
-    Session.set('features', keyword.name for keyword in @keywords)

--- a/client/stylesheets/misc.styl
+++ b/client/stylesheets/misc.styl
@@ -6,3 +6,9 @@
 .doc-content
   max-width 600px
   margin auto
+  
+.symptom-table .info
+  max-width 500px
+  margin auto
+  border 1px solid gray
+  padding 1em

--- a/routes/client.coffee
+++ b/routes/client.coffee
@@ -100,17 +100,6 @@ Router.map () ->
       $('.popover').remove()
   )
 
-  @route("symptomTable",
-    path: '/symptomTable/:_id'
-    where: 'client'
-    onBeforeAction: () ->
-      AccountsEntry.signInRequired(@)
-    waitOn: () ->
-      Meteor.subscribe('results')
-    data: () ->
-      Results.findOne(@params._id)
-  )
-
   @route("new",
     where: 'client'
     onBeforeAction: () ->


### PR DESCRIPTION
I also added an explanation of the symptom table and changed the "probability" column header label to "confidence". These changes are currently deployed on grits-dev.ecohealth.io

I'm making this change now because it avoids a few bugs the symptom table page had.
