### PR TITLE
How to highlight keywords that appear in multiple categories

### DIFF
--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -58,14 +58,7 @@ Template.dash.formatDate = () ->
       return dateString
 
 Template.dash.color = () ->
-  if @categories
-    color @categories[0] + @name
-  else if @type in ['caseCount', 'hospitalizationCount', 'deathCount', 'datetime', 'adding', 'diseases', 'hosts', 'modes', 'pathogens', 'symptoms']
-    color @type + @value
-  else if @type in ['location']
-    color @type + @name
-  else if @text
-    color @text
+  color Template.dash.getIdKeyFromFeature(@)
 
 Template.dash.getIdKey = () ->
   Template.dash.getIdKeyFromFeature @
@@ -74,10 +67,10 @@ Template.dash.getIdKeyFromFeature = (feature) ->
   if feature.textOffsets
     # ids are generated from offsets so that features with content that appears
     # in mutiple places (e.g. counts) can be individually highlighted.
-    return 'o-' + feature.textOffsets.map((o)-> o[0] + '_' + o[1]).join('-')
+    return feature.type + '-o-' + feature.textOffsets.map((o)-> o[0] + '_' + o[1]).join('-')
   idKey = feature.name or feature.text or String(feature.value)
   idKey.replace(/[^A-Za-z0-9]/g, '_')
- 
+
 Template.dash.selected = () ->
   @name == Session.get('disease')
 
@@ -220,7 +213,7 @@ Template.dash.events
     # - if any of the features for that category are currently not highlighted,
     # turn highlighting on for all features in that category
     # - if all features for the category are highlighted, turn them all off.
-    # We assume that each name is unique per category  
+    # We assume that each name is unique per category
     category = $(event.target).attr('class')
     if category in ['caseCount', 'hospitalizationCount', 'deathCount',
                     'datetime', 'diseases', 'hosts', 'modes', 'pathogens',

--- a/client/controllers/text.coffee
+++ b/client/controllers/text.coffee
@@ -1,14 +1,5 @@
 color = (feature) =>
-  if feature.categories
-    colorKey = feature.categories[0] + feature.name
-  else if feature.type in ['caseCount', 'hospitalizationCount', 'deathCount', 'datetime', 'diseases', 'hosts', 'modes', 'pathogens', 'symptoms']
-    colorKey =  feature.type + feature.value
-  else if feature.type in ['location']
-    colorKey = feature.type + feature.name
-  else if feature.text
-    colorKey = feature.text
-
-  @grits.services.color colorKey
+  @grits.services.color Template.dash.getIdKeyFromFeature(feature)
 
 Template.text.highlight = (content) ->
   features = Session.get('features')
@@ -30,21 +21,22 @@ Template.text.highlight = (content) ->
       last_idx = 0
       for feature in featuresByOccurrence
         occurrence = feature.occurrence
-        # Handlebars._escape is used to prevent formatting like <a@b.com>
-        # from being injected as live html.
-        highlightedContent += Handlebars._escape(content.substring(last_idx, occurrence[0]))
-        if feature.feature.color
-          bgColor = feature.feature.color
-        else
-          bgColor = color(feature.feature)
-        highlightText = Handlebars._escape(content.substring(occurrence[0], occurrence[1]))
-        highlightedContent += """<span
-          class='label'
-          style='
-            background-color:#{bgColor};
-            box-shadow: 0px 0px 0px 2px #{bgColor};
-          '>#{highlightText}</span>"""
-        last_idx = occurrence[1]
+        if occurrence[0] >= last_idx
+          # Handlebars._escape is used to prevent formatting like <a@b.com>
+          # from being injected as live html.
+          highlightedContent += Handlebars._escape(content.substring(last_idx, occurrence[0]))
+          if feature.feature.color
+            bgColor = feature.feature.color
+          else
+            bgColor = color(feature.feature)
+          highlightText = Handlebars._escape(content.substring(occurrence[0], occurrence[1]))
+          highlightedContent += """<span
+            class='label'
+            style='
+              background-color:#{bgColor};
+              box-shadow: 0px 0px 0px 2px #{bgColor};
+            '>#{highlightText}</span>"""
+          last_idx = occurrence[1]
       highlightedContent += Handlebars._escape(content.substring(last_idx, content.length))
       return new Spacebars.SafeString(highlightedContent)
     else if features?.length > 0


### PR DESCRIPTION
@nathanathan pointed out this bug:

> On this page (https://grits-dev.ecohealth.io/dash/TBBu3TCjxE37eGKvz) when highlighting the diseases, pathogens, and symptom sections sections, sometimes the unhighlighting gets messed up.

This pr fixes the h4 click behavior, but may be wrong in other ways. 

I changed feature id to include type as well as offset, so features in multiple categories can be selected separately for each category, and made the highlighting code skip features that overlap previous ones. 

This means you could unselect a feature in one category, but it might still be highlighted in another. 

I also changed the coloring to be based on the feature id, which makes the code simpler but may not be as clear for users. 

Thoughts?
