### PR TITLE
Adding mail to ProMED link

### DIFF
--- a/client/0views/dash.jade
+++ b/client/0views/dash.jade
@@ -25,7 +25,7 @@ template(name="dash")
       .btn-group.btn-group-justified.btn-group-sm
         a.btn.btn-default.open-feedback Feedback
       .btn-group.btn-group-justified.btn-group-sm
-        a.btn.btn-default(href='#{mailtoPromedLink}') Report to ProMED
+        a.btn.btn-default(href='#{mailtoPromedLink}') Report to ProMED-mail
       +feedback
       if showKeypoints
         .keypoints

--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -125,15 +125,19 @@ Template.dash.featureSelected = (feature) ->
     ""
 
 Template.dash.mailtoPromedLink = () ->
-  encodeURI("""
-  mailto:promedmail.org?subject=#{(d.name for d in @.diseases).join('/')} Report
-  &body=***Include your name and affiliation***
+  "mailto:promed@promedmail.org?subject=[GRITS] " +
+  encodeURIComponent((d.name for d in @.diseases).join('/') + " Report") +
+  "&body=" + 
+  encodeURIComponent("""
+  This is a GRITS generated report.
+  
+  ***Include your name and affiliation***
   
   Dashboard url:
   #{window.location.toString()}
   
   Possible diagnoses:
-  #{(d.name + ', confidence=' + d.probability for d in @.diseases).join('\n')}
+  #{(d.name + ', confidence=' + Math.round(d.probability * 100) + '%' for d in @.diseases).join('\n')}
 
   Article:
   #{@.content}


### PR DESCRIPTION
This PR add a "Report to ProMED-mail" link. It generates emails like this example:

To: `promed@promedmail.org`

Subject: `[GRITS] Eastern Equine Encephalitis/Encephalitis Report`

```
This is a GRITS generated report.

***Include your name and affiliation***
Dashboard url:
http://grits.ecohealth.io/dash/woq5FyAL5nxM7uuai

Possible diagnoses:
Eastern Equine Encephalitis, confidence=19%
Encephalitis, confidence=19%

Article:
Published Date: 2014-10-15 19:55:13
Subject: PRO/AH/EDR> Eastern equine encephalitis - USA (27): (MI) human, equine 
Archive Number: 20141015.2867964

EASTERN EQUINE ENCEPHALITIS - USA (27): (MICHIGAN), HUMAN, EQUINE
*****************************************************************
A ProMED-mail post
http://www.promedmail.org
ProMED-mail is a program of the
International Society for Infectious Diseases
http://www.isid.org

In this report from Michigan:
[1] Human case
[2] Equine cases

******
[1] Human case
Date: Mon 13 Oct 2014
From: ProMED-mail Moderator Larry Lutwick <Larry.lutwick@med.wmich.edu> [edited]


A 52-year-old Mexico-born woman from Van Buren County...
```
