### PR TITLE
Removing keyword generation from autocomplete collection creation script

### DIFF
--- a/.scripts/autocompleteCollections.js
+++ b/.scripts/autocompleteCollections.js
@@ -1,52 +1,21 @@
 // This code accesses mongo to do a map-reduce query
-// that creates a collection with the distinct keywords
-// used in the diagnoses and their categories.
-// Run it with the mongo command.
+// that creates a collection with the distinct disease classifications
+// that have been applied to articles in the girder database.
+// The disease classifications are used by the autocomplete on the search page.
 var mongodb = new Mongo('localhost:27017');
 var db = mongodb.getDB('girder');
 var collection = db.item;
-var map = function () {
-  if (this.meta.diagnosis && this.meta.diagnosis.keywords_found) {
-    this.meta.diagnosis.keywords_found.forEach(function (kw) {
-      emit(kw.name, { categories : kw.categories});
-    });
-  }
-};
-var reduce = function (kwName, listOfListsOfCategories) {
-  var out = listOfListsOfCategories.reduce(function (sofar, cur) {
-    cur.categories.forEach(function (cat) {
-      sofar.categories[cat] = true;
-    });
-    return sofar;
-  }, { categories : {} });
-  out.categories = Object.keys(out.categories);
-  return out;
-};
-
-collection.mapReduce(map, reduce,
-  { out: { "replace" : "keywords" }},
-  function(err,result) {
-    if (err) { throw err; }
-    console.log("keyword collection created");
-  }
+collection.mapReduce(
+  function () {
+    if (this.meta.diagnosis && this.meta.diagnosis.diseases) {
+      this.meta.diagnosis.diseases.forEach(function (disease) {
+        emit(disease.name, 1);
+      });
+    }
+  },
+  function (disease, values) {
+    return Array.sum(values);
+  },
+  { out: { "replace" : "diseaseNames" } }
 );
-
-// This code is similar to the code above, but it creates a collection of
-// distinct diseases we've diagnosed.
-var map = function () {
-  if (this.meta.diagnosis && this.meta.diagnosis.diseases) {
-    this.meta.diagnosis.diseases.forEach(function (disease) {
-      emit(disease.name, 1);
-    });
-  }
-};
-var reduce = function (disease, values) {
-  return Array.sum(values);
-};
-collection.mapReduce(map, reduce,
-  { out: { "replace" : "diseaseNames" }},
-  function(err,result) {
-    if (err) { throw err; }
-    console.log("diseaseNames collection created");
-  }
-);
+print("Disease name colleciton created");


### PR DESCRIPTION
The keyword collection generation is the autocomplete script is broken and slows down deployments by quite a bit. The property it gets keywords from is no longer returned by the diagnosis API. We could add the property back, but we would need to reprocess all the articles and it is not necessary for anything else. Furthermore, there are other ways we can populate the autocomplete and we could remove the autocomplete entirely since it is not a high-priority feature.
