### PR TITLE
Adding support for rediagnosing with BSVE key

### DIFF
--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -255,11 +255,19 @@ Template.dash.events
     Session.set('feedbackShowing', true)
 
   "click .rediagnose": (event) ->
-    Meteor.call('rediagnose', @, (error, resultId) ->
+    bsveAccessKey = Router.current().params.query.bsveAccessKey
+    submission = {
+      prevDiagnosis: @
+      content: @content
+      accessKey: bsveAccessKey
+    }
+    Meteor.call('submit', submission, (error, resultId) ->
       if error
         alert "Could not rediagnose: " + error.message
       else
-        Router.go 'dash', {_id: resultId}
+        Router.go 'dash', {_id: resultId}, {
+          query: "bsveAccessKey=#{bsveAccessKey}" if bsveAccessKey
+        }
     )
 
   "click .features h4": (event, template) ->

--- a/routes/client.coffee
+++ b/routes/client.coffee
@@ -101,7 +101,10 @@ Router.map () ->
         alert('Invalid value for showKeypoints')
       result = @data()
       if result?.error and result?.updatedDiagnosisId
-        Router.go "dash", {_id: result.updatedDiagnosisId}
+        bsveAccessKey = @params.query.bsveAccessKey
+        Router.go "dash", {_id: result.updatedDiagnosisId}, {
+          query: "bsveAccessKey=#{bsveAccessKey}" if bsveAccessKey
+        }
     onStop: () ->
       Session.set('disease', null)
       Session.set('features', [])

--- a/server/submit.coffee
+++ b/server/submit.coffee
@@ -83,10 +83,4 @@ Meteor.methods(
         userId: @userId
     result
 
-  'rediagnose' : (prevDiagnosis) ->
-    submit
-      text: prevDiagnosis.content
-      userId: @userId
-      prevDiagnosis: prevDiagnosis
-
 )


### PR DESCRIPTION
Currently, if there is a BSVE user encounters an error when diagnosing an article and they click the retry button they will see an "user not authenticated" error. This PR makes it so that doesn't happen.
