### PR TITLE
Show text of submenu items on hover on smaller screens

### DIFF
--- a/client/stylesheets/dash.import.styl
+++ b/client/stylesheets/dash.import.styl
@@ -218,6 +218,13 @@
       .fa
         font-size 1.25em
         margin 0
+      &:hover
+        span
+          display block
+          font-size .9em
+          line-height 1.2em
+        .fa
+          display none
 
 .text-container
 .symptom-container


### PR DESCRIPTION
An alternative to tooltips - just simply show the text instead of the icon on the hover state.

PT story: https://www.pivotaltracker.com/story/show/131775103