### PR TITLE
Make sidebar and diagnosis UI more responsive

### DIFF
--- a/.meteor/versions
+++ b/.meteor/versions
@@ -84,7 +84,7 @@ standard-app-packages@1.0.3
 tangelo@0.0.0
 templating@1.0.9
 tracker@1.0.3
-twbs:bootstrap@3.3.1_2
+twbs:bootstrap@3.3.6
 ui@1.0.4
 underscore@1.0.1
 url@1.0.2

--- a/client/0views/dash.jade
+++ b/client/0views/dash.jade
@@ -171,5 +171,7 @@ template(name="dash")
             if featuresSelected
               .text-options
                 a.clear-annotations Clear Annotations
-  if signedIn
-    +feedback
+
+    //- Feedback Modal
+    if signedIn
+      +feedback

--- a/client/0views/dash.jade
+++ b/client/0views/dash.jade
@@ -29,13 +29,24 @@ template(name="dash")
             a.btn.btn-default.prev-diagnosis(href='/dash/#{updatedDiagnosisId}') Updated Diagnosis
           else
             a.btn.btn-default.rediagnose Rediagnose
-        .btn-group.btn-group-justified.btn-group-sm
-          a.btn.btn-default.open-feedback(data-toggle="modal" data-target="#feedback-modal") Feedback
-      .find-btns
-        a.btn.btn-default(href='/searchEidr?diagnosisId=#{_id}') Find Similar Disease Emergence Events
-      //  a.btn.btn-default(href='/searchGirder?diagnosisId=#{_id}') Find Similar Articles
-      .btn-group.btn-group-justified.btn-group-sm
-        a.btn.btn-default(href='#{mailtoPromedLink}') Report to ProMED-mail
+      .secondary-actions
+        if signedIn
+          a.open-feedback(data-toggle="modal" data-target="#feedback-modal")
+            i.fa.fa-comment(
+              data-toggle="tooltip"
+              data-placement="bottom"
+              title="Feedback")
+          a(href='/searchEidr?diagnosisId=#{_id}'
+            data-toggle="tooltip"
+            data-placement="bottom"
+            title="Find Similar Disease Emergence Events")
+            i.fa.fa-search
+        a(href='#{mailtoPromedLink}'
+          data-toggle="tooltip"
+          data-placement="bottom"
+          title="Report to ProMED-mail")
+          i.fa.fa-envelope
+
       if showKeypoints
         .keypoints
           h4 Key Points

--- a/client/0views/eidr_result_list.jade
+++ b/client/0views/eidr_result_list.jade
@@ -1,5 +1,5 @@
 template(name="eidrResultList")
-  div(class="search-results")
+  .search-results-list
     h4 Search Results:
     each results
       div(class="search-result")

--- a/client/0views/feedback.jade
+++ b/client/0views/feedback.jade
@@ -30,12 +30,15 @@ template(name="feedback")
                     .col-sm-8.col-xs-8
                       input.form-control.with-btn(readonly=readonly value="{{name}}" disabled)
                     .col-sm-1.col-xs-1.disease-button-container
-                      i.fa.fa-times-circle.remove-disease(data-name="{{name}}")
+                      i.fa.fa-times-circle.remove-selection(data-name="{{name}}")
               .row
                 .col-sm-8
                   +inputAutocomplete settings=diseaseCompleteSettings id="new-disease" name="missing_diseases" class="form-control with-btn"
                 .col-sm-1.disease-button-container
-                  i.fa.fa-plus-circle.add-disease(id="add-disease" type="button" class="btn-plain btn" disabled="{{#unless addDiseaseEnabled}} disabled {{/unless}}")
+                  i.fa.fa-plus-circle.add-disease.add-selection.btn.btn-plain(
+                    id="add-disease"
+                    type="button"
+                    disabled="{{#unless addDiseaseEnabled}} disabled {{/unless}}")
 
             .form-group
               label(for="comments") Diagnosis Comments:

--- a/client/0views/feedback.jade
+++ b/client/0views/feedback.jade
@@ -4,6 +4,7 @@ template(name="feedback")
       .modal-content
         .modal-header
           h2 Feedback
+          i.fa.fa-times-circle.close-modal(data-dismiss="modal" aria-label="Close")
         form.feedback
           .modal-body
             .form-group
@@ -26,13 +27,13 @@ template(name="feedback")
               div
                 each missingDiseases
                   .row.added-disease
-                    .col-sm-8
-                      input.form-control(readonly=readonly value="{{name}}" disabled)
-                    .col-sm-1.disease-button-container
+                    .col-sm-8.col-xs-8
+                      input.form-control.with-btn(readonly=readonly value="{{name}}" disabled)
+                    .col-sm-1.col-xs-1.disease-button-container
                       i.fa.fa-times-circle.remove-disease(data-name="{{name}}")
               .row
                 .col-sm-8
-                  +inputAutocomplete settings=diseaseCompleteSettings id="new-disease" name="missing_diseases" class="form-control"
+                  +inputAutocomplete settings=diseaseCompleteSettings id="new-disease" name="missing_diseases" class="form-control with-btn"
                 .col-sm-1.disease-button-container
                   i.fa.fa-plus-circle.add-disease(id="add-disease" type="button" class="btn-plain btn" disabled="{{#unless addDiseaseEnabled}} disabled {{/unless}}")
 

--- a/client/0views/search.jade
+++ b/client/0views/search.jade
@@ -10,7 +10,7 @@ template(name="searchInput")
       .col-xs-9.input-wrap
         +inputAutocomplete settings=autocompleteSettings class="form-control input-xlarge add-selection-input"
       .col-xs-2
-        button.btn.btn-default(class="add-selection") Add
+        i.fa.fa-plus-circle.add-selection.btn.btn-plain
 
 template(name="selector")
   each itemsInCollection
@@ -21,7 +21,7 @@ template(name="selector")
     .col-xs-9.input-wrap
       input.input-xlarge.form-control
     .col-xs-2
-      button.add-item.btn.btn-default Add
+      i.fa.fa-plus-circle.add-selection.btn.btn-plain
 
 template(name="searchPill")
   span(class="sp-label") {{_id}}
@@ -31,11 +31,11 @@ template(name="searchPill")
 
 template(name="searchAggregations")
 
-  h4 In one of these countries:
+  .feature-section--header
+    h4 In one of these countries:
   .left-panel-block
     +selector collection=selections.CountriesSelected
-    div
-      b Approximate Document Counts:
+    h6 Approximate Document Counts:
     each aggregations.countries.buckets
       .document-count
         span.count-bar(style="width: {{percentage doc_count ../totalResults}}%;")
@@ -43,7 +43,8 @@ template(name="searchAggregations")
           a.add-country-filter(href="#" data-name="{{key}}") {{key}}
           span : {{doc_count}} reports
 
-  h4 In the date range:
+  .feature-section--header
+    h4 In the date range:
   .left-panel-block
     .form-inline
       .form-group
@@ -52,8 +53,7 @@ template(name="searchAggregations")
       .form-group
         label.date-label End
         input.date-selector.to-date.form-control(type="date" value="{{toDate}}")
-    div
-      b Approximate Document Counts:
+    h6 Approximate Document Counts:
     each aggregations.dates.buckets
       if doc_count
         .document-count
@@ -65,26 +65,13 @@ template(name="searchAggregations")
 
 template(name="search")
   .dashboard-container
-    .left-panel.search-sidebar
-      h3 Find #{label} with...
+    .panel-header(class="{{#unless sideBarOpen}} closed side-bar-toggle {{/unless}}")
+      h4.diagnosis-heading  Find #{label} with...
+      .side-bar-toggle.toggle-icon
+        i.fa(class="{{#if sideBarOpen}} fa-arrow-circle-o-left {{else}} fa-arrow-circle-o-right {{/if}}")
 
-      h4 Any of these diseases:
-      .left-panel-block
-        +searchInput selected=selections.DiseasesSelected autocompleteCollection=diseaseNames restrictToAutocomplete="true"
-
-      h4 Any of these keywords:
-      .left-panel-block
-        +searchInput selected=selections.AnyKeywordsSelected autocompleteCollection=keywords
-
-      h4 All of these keywords:
-      .left-panel-block
-        +searchInput selected=selections.AllKeywordsSelected autocompleteCollection=keywords
-
-      +searchAggregations totalResults=totalResults selections=selections fromDate=fromDate toDate=toDate formatDateRange=formatDateRange aggregations=aggregations
-
-
-    .pane-container.search
-      .vis-pane-bar
+    .vis-pane-bar(class="{{#unless sideBarOpen}} full-width {{/unless}}")
+      .search-results-details
         if numResults
           span
             | Page {{pageNum}}
@@ -115,16 +102,36 @@ template(name="search")
                   option(selected value=name) {{label}}
                 else
                   option(value=name) {{label}}
-      .vis-pane
-        if searching
-          p Searching...
-        else if eq useView "listView"
-          +Template.dynamic template=resultListTemplate data=resultListData
-        else if eq useView "mapView"
-          +geomapSimple
-        else if eq useView "dateGroupView"
-          +dateGroups
-        else if eq useView "locationGroupView"
-          +locationGroups
-        else if eq useView "diseaseGroupView"
-          +diseaseGroups
+
+    .left-panel.search-sidebar(class="{{#unless sideBarOpen}} closed {{/unless}}")
+      .feature-section--header
+        h4 Any of these diseases:
+      .left-panel-block
+        +searchInput selected=selections.DiseasesSelected autocompleteCollection=diseaseNames restrictToAutocomplete="true"
+
+      .feature-section--header
+        h4 Any of these keywords:
+      .left-panel-block
+        +searchInput selected=selections.AnyKeywordsSelected autocompleteCollection=keywords
+
+      .feature-section--header
+        h4 All of these keywords:
+      .left-panel-block
+        +searchInput selected=selections.AllKeywordsSelected autocompleteCollection=keywords
+
+      +searchAggregations totalResults=totalResults selections=selections fromDate=fromDate toDate=toDate formatDateRange=formatDateRange aggregations=aggregations
+
+
+    .pane-container.search-results(class="{{#unless sideBarOpen}} full-width {{/unless}}")
+      if searching
+        p Searching...
+      else if eq useView "listView"
+        +Template.dynamic template=resultListTemplate data=resultListData
+      else if eq useView "mapView"
+        +geomapSimple
+      else if eq useView "dateGroupView"
+        +dateGroups
+      else if eq useView "locationGroupView"
+        +locationGroups
+      else if eq useView "diseaseGroupView"
+        +diseaseGroups

--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -6,6 +6,7 @@ Template.dash.created = ->
 
 Template.dash.rendered = ->
   Session.set('features', @data.features)
+  @$('[data-toggle="tooltip"]').tooltip()
 
 DISABLE_MULTI_HIGHLIGHT = true
 color = (text) =>
@@ -89,21 +90,28 @@ Template.dash.helpers
   tableSettings: ->
     fields: [
       {
+        key: 'name',
+        label: 'Disease'
+        fn: (value) ->
+          new Spacebars.SafeString("<span>#{value}</span>");
+      },
+      {
         key: 'probability'
         label: 'Confidence'
         sort: -1
-        fn: (prob) ->
-          Math.round(prob * 1000) / 1000
+        fn: (value) ->
+          prob = value.toFixed(4) * 100
+          new Spacebars.SafeString("<span>#{prob}%</span>");
       },
-      { key: 'name', label: 'Disease' },
       {
         key: 'keywords'
         label: 'Characteristics'
         fn: (features) ->
-          html = ""
+          html = '<div>'
           _.each features, (feature) ->
             bgColor = color feature.name
             html += "<span style='background-color:#{bgColor}'></span>"
+          html += '</div>'
           Spacebars.SafeString html
       }
     ]

--- a/client/controllers/feedback.coffee
+++ b/client/controllers/feedback.coffee
@@ -101,5 +101,5 @@ if Meteor.isClient
       if $("#new-disease").val()
         instance.missingDiseases.insert({name : $("#new-disease").val()})
 
-    "click .remove-disease" : (event, instance) ->
+    "click .remove-selection" : (event, instance) ->
       instance.missingDiseases.remove({name : $(event.currentTarget).data('name')})

--- a/client/controllers/symptomTable.coffee
+++ b/client/controllers/symptomTable.coffee
@@ -15,13 +15,21 @@ Template.symptomTable.tableSettings = () ->
      .uniq()
      .value()
   fields: [
-    { key: 'name', label: 'Disease' },
+    {
+      key: 'name'
+      label: 'Disease'
+      fn: (value) ->
+        Spacebars.SafeString "<span>#{value}</span>"
+    },
   ].concat(_.map symptoms, (name)->
     {
       key: name
       label: name
       fn: (score) ->
-        Math.round(score * 1000) / 1000
+        html = '<span>'
+        _score = Math.round(score * 1000) / 1000
+        html += "#{_score}</span>"
+        Spacebars.SafeString html
     }
   )
   showNavigation: 'never'

--- a/client/stylesheets/dash.import.styl
+++ b/client/stylesheets/dash.import.styl
@@ -1,5 +1,5 @@
 .dashboard-container
-  position fixed
+  position absolute
   top $header-height
   left 0
   right 0

--- a/client/stylesheets/dash.import.styl
+++ b/client/stylesheets/dash.import.styl
@@ -51,11 +51,18 @@
   min-height 50px
   display flex
   align-items center
-  width 350px
+  width $left-pane-width-small
   min-height 50px
   border-right 2px solid #CCC
   transition $transition-time ease-in-out
   z-index 10
+  font-size 16px
+  +above(3)
+    width $left-pane-width
+  h4
+    font-size 16px
+    +above(3)
+      font-size 18px
   &.closed
     width 200px
     h4
@@ -71,8 +78,11 @@
   cursor pointer
   background-color #f9f9f9
   border-bottom-color darken(@background-color, 15%)
-  margin-left -20px
-  margin-right -20px
+  margin-left -5px
+  margin-right -5px
+  +above(3)
+    margin-left -20px
+    margin-right -20px
   &:hover
     background-color $primary-muted
     color black
@@ -100,41 +110,122 @@
   background-color #FFF
   overflow-x scroll
   -ms-overflow-style -ms-autohiding-scrollbar
-  padding 0 20px
-  width $left-pane-width
+  padding 0 5px
+  width $left-pane-width-small
   top 50px
   bottom 0
   transition $transition-time ease-in-out
   opacity 1
+  +above(3)
+    width $left-pane-width
+    padding 0 20px
   &.closed
-    transform translate(-1 * $left-pane-width, 0)
+    transform translate(-1 * $left-pane-width-small, 0)
     opacity 0
+    +above(3)
+      transform translate(-1 * $left-pane-width, 0)
 
-  .reactive-table
-    width $left-pane-width - 2
-    max-width $left-pane-width - 2
-    margin-left -20px
-    margin-right -20px
+  .btn-group .btn
+    margin-bottom 10px
+    +below(3)
+      display block
+      width 95%
+      margin-left auto
+      margin-right auto
+      margin-bottom .5em
+      border-radius 4px !important //Overide the btn-group bootstrap styles
+
+.left-panel
+  .table
+    width $left-pane-width-small - 2
+    max-width $left-pane-width-small - 2
+    margin-left -5px
+    margin-right -5px
     font-size 13px
+    +above(3)
+      width $left-pane-width - 2
+      max-width $left-pane-width - 2
+      margin-left -20px
+      margin-right -20px
     tr
       cursor pointer
       &.selected
-        background-color desaturate(lighten(#DEEDDC, 20%),40%)
+        td
+          &:first-of-type
+            background darken(#f9f9f9, 2%)
+      +below(3)
+        background-color white !important // Overide styles applied by reactive table
+        border-bottom 2px solid #CCC
       td
         max-width 32%
-        &:first-of-type
-          padding-left 15px
-        &:last-of-type
+        +above(3)
+          &:first-of-type
+            padding-left 15px
+          &:last-of-type
+            padding-right 15px
+        +below(3)
+          border 0
+          max-width 100%
+          display flex
+          align-items center
+          padding-top 5px
+          padding-bottom 5px
           padding-right 15px
+          padding-left 15px
+          > span
+            display block
+          &:before
+            margin-right 1em
+          &:first-of-type
+            padding 10px
+            border-bottom 1px solid #CCC
+          &:nth-of-type(2):before
+            content 'Confidence'
+          &:nth-of-type(3):before
+            content 'Characteristics'
+        +below(2)
+          align-items flex-start
+          flex-direction column
+          &:before
+            margin-bottom 3px
+        &:first-of-type
+          > span
+            font-weight bold
     th
       &:first-of-type
         padding-left 15px
       &:last-of-type
         padding-right 15px
 
-  .btn-group
-    margin-bottom 10px
-
+.symptom-table
+  .reactive-table-options
+    display none
+  .table
+    +below(4)
+      width 100%
+      thead
+        display none
+    tr
+      +below(4)
+        background none !important // Override srtiped styling
+        &:hover
+          background none
+      td
+        +below(4)
+          display flex
+          align-items center
+          justify-content flex-start
+          &:first-of-type
+            font-weight bold
+            &:before
+              content ''
+              display none
+          &:before
+            flex 1
+            content attr(class)
+            text-transform capitalize
+          span
+            flex 4
 
 .feature-section
 .keypoints
@@ -147,15 +238,22 @@
     font-size 1em
     font-weight normal
     padding 7px 10px
-    text-shadow 0 1px 1px rgba(0,0,0,.4)
     letter-spacing .03em
+    text-shadow none
     box-shadow 0 1px 1px rgba(255,255,255,0)
     -webkit-font-smoothing subpixel-antialiased
     &:hover
       box-shadow 0px 0px 0px 2px rgba(100,100,100,.5)
+      +below(3)
+        box-shadow 0px 0px 0px 1px rgba(100,100,100,.5)
+    +below(3)
+      font-size .85em
+      padding 5px 8px
 
   .label.selected
     box-shadow 0px 0px 0px 2px rgba(100,100,100,.9)
+    +below(3)
+      box-shadow 0px 0px 0px 1px rgba(100,100,100,.9)
 
 .features
   margin 25px 0 70px 0
@@ -173,11 +271,12 @@
 .keywords
   span
     display inline-block
-    margin-bottom 5px
-    min-height 20px
+    min-height 15px
+    min-width 5px
     margin-right 5px
-    width 5px
     border-radius 1px
+    +above(3)
+      min-height 20px
 
 .find-btns
   margin-top 20px
@@ -243,3 +342,15 @@
     &:hover
       text-decoration none
       color $confirm
+
+.secondary-actions
+  display flex
+  align-items center
+  justify-content center
+  margin 10px 0
+  a
+    color #CCC
+    font-size 1.5em
+    margin 0 .75em
+    i
+      cursor pointer

--- a/client/stylesheets/dash.import.styl
+++ b/client/stylesheets/dash.import.styl
@@ -60,9 +60,10 @@
   +above(3)
     width $left-pane-width
   h4
-    font-size 16px
+    font-size 15px
+    padding-right 30px
     +above(3)
-      font-size 18px
+      font-size 16px
   &.closed
     width 200px
     h4
@@ -80,6 +81,8 @@
   border-bottom-color darken(@background-color, 15%)
   margin-left -5px
   margin-right -5px
+  h4
+    font-size 14px
   +above(3)
     margin-left -20px
     margin-right -20px
@@ -134,6 +137,9 @@
       margin-right auto
       margin-bottom .5em
       border-radius 4px !important //Overide the btn-group bootstrap styles
+  h6
+    font-size 15px
+
 
 .left-panel
   .table

--- a/client/stylesheets/feedback.import.styl
+++ b/client/stylesheets/feedback.import.styl
@@ -58,17 +58,5 @@
   .disease-button-container
     padding-left 0
 
-  .remove-disease
-  .add-disease
-    pointer()
-    font-size 1.5em
-    color $blue
-    padding-top .3em
-    &[disabled]
-      cursor not-allowed
-
-  .remove-disease
-    color $delete
-
   .added-disease
     margin-bottom 10px

--- a/client/stylesheets/feedback.import.styl
+++ b/client/stylesheets/feedback.import.styl
@@ -1,5 +1,4 @@
 .feedback
-
   h2
     margin 0
     font-weight 700
@@ -15,6 +14,12 @@
     margin-bottom 20px
     &:last-of-type
       margin-bottom 0
+    .form-control
+      &.with-btn
+        +below(2)
+          width 90%
+          float left
+          margin-right 1em
 
   textarea
     margin-bottom 30px
@@ -24,21 +29,6 @@
 
   .control-label
     font-weight normal
-
-  .modal-content
-    border-radius 4px
-
-  .modal-body
-    padding 20px
-
-  .modal-header
-    background $primary-muted
-    border-top-left-radius 4px
-    border-top-right-radius 4px
-
-  .modal-footer
-    border 0
-    padding 20px 20px 40px 20px
 
   .form-buttons
     width 100%
@@ -60,6 +50,10 @@
     font-size .95em
     label
       color #444
+      &:last-of-type
+        +below(2)
+          display block
+          margin-left 0
 
   .disease-button-container
     padding-left 0

--- a/client/stylesheets/globals.import.styl
+++ b/client/stylesheets/globals.import.styl
@@ -32,6 +32,9 @@ body
 .no-margin
   margin 0 !important
 
+.muted-text
+  color #CCC
+
 label
   .info
     display block
@@ -45,3 +48,27 @@ label
   font-family 'Open Sans'
   > .tooltip-inner
     background-color alpha(black, 95%)
+
+.no-results
+  margin-top 20px
+  padding 0 15px
+  text-align center
+  @extend .muted-text
+  &::before
+    display block
+    content '\f002'
+    icon()
+    font-size 250%
+    margin-bottom 10px
+
+.remove-selection
+.add-selection
+  pointer()
+  font-size 1.5em
+  color $blue
+  padding-top .3em
+  &[disabled]
+    cursor not-allowed
+
+.remove-selection
+  color $delete

--- a/client/stylesheets/globals.import.styl
+++ b/client/stylesheets/globals.import.styl
@@ -39,3 +39,9 @@ label
     font-weight normal
     color lighten(#333, 10%)
     margin-bottom 10px
+
+.tooltip
+  text-shadow none
+  font-family 'Open Sans'
+  > .tooltip-inner
+    background-color alpha(black, 95%)

--- a/client/stylesheets/index.styl
+++ b/client/stylesheets/index.styl
@@ -1,10 +1,12 @@
 @import 'nib'
 @require 'rupture'
+@import 'vendor_settings.import'
 
 @require 'mixins.import'
 @require 'variables.import'
 
 @import 'globals.import.styl'
+@import 'tables.import.styl'
 
 @import 'loading.import'
 @import 'accounts.import'

--- a/client/stylesheets/index.styl
+++ b/client/stylesheets/index.styl
@@ -7,6 +7,7 @@
 
 @import 'globals.import.styl'
 @import 'tables.import.styl'
+@import 'modals.import.styl'
 
 @import 'loading.import'
 @import 'accounts.import'

--- a/client/stylesheets/index.styl
+++ b/client/stylesheets/index.styl
@@ -8,8 +8,9 @@
 @import 'globals.import.styl'
 @import 'tables.import.styl'
 @import 'modals.import.styl'
-
 @import 'loading.import'
+
+@import 'profile.import'
 @import 'accounts.import'
 @import 'correlation.import'
 @import 'dash.import'
@@ -21,7 +22,6 @@
 @import 'layout.import'
 @import 'misc.import'
 @import 'new_diagnosis.import'
-@import 'profile.import'
 @import 'search.import'
 @import 'splash.import'
 @import 'text.import'

--- a/client/stylesheets/layout.import.styl
+++ b/client/stylesheets/layout.import.styl
@@ -5,29 +5,33 @@ body
 
 .pane-container
   position absolute
-  left $left-pane-width
+  left $left-pane-width-small
   right 0
   top 0
   bottom 0
   overflow auto
   transition $transition-time ease-in-out
   margin-left 0
+  +above(3)
+    left $left-pane-width
   &.full-width
     left 0
 
 .vis-pane-bar
   background-color $primary-muted
   color black
-  width 100%
+  width 'calc(100% - %s)' % $left-pane-width-small
   border-bottom 1px solid $primary-border
   position relative
   z-index 99
-  left 350px
+  left $left-pane-width-small
   transition $transition-time ease-in-out
+  +above(3)
+    left $left-pane-width
+    width 'calc(100% - %s)' % $left-pane-width
   &.full-width
-    left 200px
-    .tabs
-      width calc(100% - 200px)
+    left $closed-sidebar-toggle-width
+    width 'calc(100% - %s)' % $left-pane-width-small
 
 .vis-pane
   overflow auto
@@ -53,7 +57,6 @@ body
   align-items stretch
   margin 0
   padding 0
-  width calc(100% - 350px)
   transition width $transition-time ease-in-out
   transition-delay $transition-time - .2
   li

--- a/client/stylesheets/layout.import.styl
+++ b/client/stylesheets/layout.import.styl
@@ -18,6 +18,7 @@ body
     left 0
 
 .vis-pane-bar
+  min-height 50px
   background-color $primary-muted
   color black
   width 'calc(100% - %s)' % $left-pane-width-small

--- a/client/stylesheets/modals.import.styl
+++ b/client/stylesheets/modals.import.styl
@@ -1,0 +1,34 @@
+.modal
+  z-index 1000000
+
+.modal-header
+  position relative
+
+.modal-content
+  border-radius 4px
+
+.modal-body
+  padding 20px
+
+.modal-header
+  background $primary-muted
+  border-top-left-radius 4px
+  border-top-right-radius 4px
+
+.modal-footer
+  border 0
+  padding 20px 20px 40px 20px
+
+.close-modal
+  position absolute
+  right 1em
+  top .75em
+  cursor pointer
+  color $m-gray
+  padding .25em
+  &:hover
+    color $secondary-dark
+  &::before
+    font-family FontAwesome
+    content '\f057'
+    font-size 1.65em

--- a/client/stylesheets/profile.import.styl
+++ b/client/stylesheets/profile.import.styl
@@ -3,7 +3,32 @@
 
 .dashboard-list
   margin 20px 50px
-
-  .reactive-table
-    tr
-      cursor pointer
+  .table.reactive-table
+    +below(3)
+      margin-left -50px
+      margin-right -50px
+      width calc(100% + 100px)
+      max-width calc(100% + 100px)
+    tbody
+      tr
+        cursor pointer
+        td
+          border 0
+        +below(3)
+          display block
+          border-top 0
+          border-bottom 1px solid lighten(#CCC, 20%)
+          padding 10px 50px
+          &:empty
+            display none
+          td
+            padding-right 0
+            padding-left 0
+            &.diseases
+              font-weight bold
+              font-size 16px
+            &.content
+              font-style italic
+            &.createDate
+              font-size 12px
+              text-align right

--- a/client/stylesheets/search.import.styl
+++ b/client/stylesheets/search.import.styl
@@ -4,6 +4,7 @@
   margin-left 10px
   white-space nowrap
   overflow hidden
+
 .sp-category
   color blue
   font-size 10pt
@@ -11,14 +12,33 @@
 .sp-label
   display inline-block
 
+.search-results-details
+  min-height 49px
+  display flex
+  align-items center
+  align-content center
+  justify-content flex-start
+  padding-left 15px
+  span
+    align-content center
+
+.search-results
+  padding-top 60px
+  padding-left 15px
+  padding-right 15px
+
 .search-result
   padding 2px
 
 .search-result:nth-child(2n)
   background-color #eee
 
-.search-results
-  padding 0px 5px
+.search-sidebar
+  .feature-section--header
+    &:hover
+      cursor default
+      background-color #f9f9f9
+
 
 .title-link
   display block
@@ -97,4 +117,3 @@
 
 .left-panel-block
   padding 5px 0
-

--- a/client/stylesheets/tables.import.styl
+++ b/client/stylesheets/tables.import.styl
@@ -1,0 +1,17 @@
++below(3)
+  thead
+    tr
+      position absolute
+      top -9999px
+      left -9999px
+  tr
+    border 1px solid #ccc
+  td
+    border none
+    position relative
+    padding-left 50%
+    display block
+    background-color none
+
+  .reactive-table-options
+    display none

--- a/client/stylesheets/text.import.styl
+++ b/client/stylesheets/text.import.styl
@@ -16,9 +16,11 @@
     border-bottom-left-radius 3px
     border-bottom-right-radius 3px
     line-height 1.6em
+    font-size 1em
     +below(800px)
       padding-left 1.5em
       padding-right 1.5em
+      font-size .9em
   .label
     padding 0
     margin 0

--- a/client/stylesheets/variables.import.styl
+++ b/client/stylesheets/variables.import.styl
@@ -1,4 +1,7 @@
-$left-pane-width    = 350px
+$left-pane-width             = 350px
+$left-pane-width-small       = $left-pane-width - 150px
+$closed-sidebar-toggle-width = $left-pane-width-small
+
 $background-color   = #f9f9f9
 $header-height      = 50px
 $primary            = #2B9DA1

--- a/client/stylesheets/vendor_settings.import.styl
+++ b/client/stylesheets/vendor_settings.import.styl
@@ -1,0 +1,4 @@
+// Rupture Scale (Follows Bootstrap)
+rupture.scale = 0        480px        768px      992px      1200px
+//              └────┬────┘ └────┬────┘ └────┬────┘ └────┬────┘└────┬────┘
+//                   1           2           3           4          5


### PR DESCRIPTION
@nathanathan This PR goes a little further with the responsiveness of the sidebar and diagnosis UI.
- decreases width of sidebar under 768px
- makes contents of sidebar responsive
- declutters button area in sidebar — uses icons (with tooltips)
- Styles tables for smaller screens - shows stuff in a more blocked layout (especially beneficial for the detailed diagnosis or symptom table) 
- Changes confidence value in sidebar table to a percentage with 2 decimal points
- updates bootstrap package
