### PR TITLE
Fix conflicts when text is pasted and url input is not empty

### DIFF
--- a/client/0views/new.jade
+++ b/client/0views/new.jade
@@ -4,11 +4,11 @@ template(name="new")
       .submit-page.col-sm-10.col-sm-offset-1
         ul.nav.nav-tabs.upload-menu
           li.active
-            a(href='#copy', data-toggle='tab')
+            a(href='#copy', data-toggle='tab' data-source='text')
               i.fa.fa-file-text-o
               | Copy &amp; Paste
           li
-            a(href='#web', data-toggle='tab')
+            a(href='#web', data-toggle='tab' data-source='url')
               i.fa.fa-link
               | From the web
 
@@ -23,4 +23,5 @@ template(name="new")
 
         .row
           .col-sm-3.col-sm-offset-9
-            button.btn.btn-large.btn-primary.btn-block.pull-right#submit-button Diagnose
+            button.btn.btn-large.btn-primary.btn-block.pull-right#submit-button(disabled)
+              | Diagnose

--- a/client/controllers/dash.coffee
+++ b/client/controllers/dash.coffee
@@ -189,7 +189,7 @@ Template.dash.helpers
     Template.instance().sideBarOpen
 
   featuresSelected: ->
-    Session.get('features').length
+    Session.get('features')?.length
 
 Template.dash.events
   "click .diagnosis .reactive-table tbody tr" : (event) ->

--- a/client/controllers/new.coffee
+++ b/client/controllers/new.coffee
@@ -1,13 +1,41 @@
-Template.new.events
-  "click #submit-button": (instance) ->
-    $('#submit-button').prop('disabled', true)
-    text = $('#submit-text').val()
-    url  = $('#submit-url').val()
-    
-    if !/^(f|ht)tps?:\/\//i.test(url)
-      url = 'http://' + url
+Template.new.created = ->
+  @source = new ReactiveVar 'text'
 
-    Meteor.call('submit', {
+Template.new.rendered = ->
+  @autorun =>
+    source = @source.get()
+    if source is 'url' and not @$('.submit-url').val()
+      buttonState = true
+    else if source is 'text' and not @$('textarea').val()
+      buttonState = true
+    else
+      buttonState = false
+
+    @$('#submit-button').prop('disabled', buttonState)
+
+Template.new.events
+  'click .upload-menu a': (event, instance) ->
+    instance.source.set($(event.target).data('source'))
+
+  'input textarea, input .submit-url': (event, instance) ->
+    buttonState = false
+    if instance.$(event.target).val()
+      buttonState = true
+
+    instance.$('#submit-button').prop('disabled', not buttonState)
+
+  "click #submit-button": (event, instance) ->
+    $('#submit-button').prop('disabled', true)
+    if instance.source.get() is 'url'
+      url = $('#submit-url').val()
+      if !/^(f|ht)tps?:\/\//i.test(url)
+        url = 'http://' + url
+      text = null
+    else
+      text = $('#submit-text').val()
+      url = null
+
+    Meteor.call 'submit', {
       text: text,
       url: url,
       accessKey: Router.current().params.query.bsveAccessKey
@@ -23,4 +51,3 @@ Template.new.events
         Router.go 'dash', {_id: resultId}, {
           query: "bsveAccessKey=#{bsveAccessKey}" if bsveAccessKey
         }
-    )


### PR DESCRIPTION
@nathanathan I think this fixes [this bug](https://www.pivotaltracker.com/story/show/134338841)? I don't have stuff setup to scrape the url but when both inputs have text, and the user submits on the _from the web_ tab, the api seems to process the text with no error (and vice versa).